### PR TITLE
Feature/collapse post table of contents

### DIFF
--- a/src/components/blocks/TableOfContents.astro
+++ b/src/components/blocks/TableOfContents.astro
@@ -29,7 +29,11 @@ const listHtml = headings
 	.join('');
 ---
 
+{
+	listHtml && headings.length > 1 ? (
 		<details class='toc' open>
 			<summary>Contents</summary>
 			<ol set:html={listHtml} />
 		</details>
+	) : null
+}

--- a/src/components/blocks/TableOfContents.astro
+++ b/src/components/blocks/TableOfContents.astro
@@ -29,4 +29,7 @@ const listHtml = headings
 	.join('');
 ---
 
-<ol class='toc' set:html={listHtml} />
+		<details class='toc' open>
+			<summary>Contents</summary>
+			<ol set:html={listHtml} />
+		</details>

--- a/src/styles/components/TableOfContents.scss
+++ b/src/styles/components/TableOfContents.scss
@@ -1,24 +1,27 @@
 .toc {
 	display: inline-block;
-	counter-reset: item;
-	padding: 8px;
 	margin-bottom: 16px;
+	padding: 8px;
 	border: 1px solid $c-border;
 
-	ol {
+	& > ol {
+		padding: 0;
 		counter-reset: item;
-		padding-left: 1.5em;
+
+		ol {
+			padding-left: 1.5em;
+			counter-reset: item;
+		}
 	}
 
 	li {
 		display: block;
 		line-height: 0.75;
-		font-size: 0.95em;
 
 		&::before {
+			margin-right: 0.5em;
 			content: counters(item, '.');
 			counter-increment: item;
-			margin-right: 0.5em;
 		}
 
 		&:hover {
@@ -29,8 +32,8 @@
 		}
 
 		a {
-			line-height: 1.15;
 			text-decoration: none;
+			line-height: 1.15;
 		}
 	}
 }


### PR DESCRIPTION
Made TOC collapsible using the HTML `details` element. Also, TOC is not generated on posts with less than 2 headings.

![image](https://user-images.githubusercontent.com/23709455/221963217-b043ff70-514a-4841-975a-9edc6abcbd33.png)

![image](https://user-images.githubusercontent.com/23709455/221963031-6ba670c3-6613-4c2a-ac62-95126e974c2e.png)
