### PR TITLE
set config to build page files instead of directories

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,9 @@ import shikiTheme from './shikiTheme.json';
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://kainoa.us',
+	build: {
+		format: 'file',
+	},
 	integrations: [mdx(), sitemap(), image(), robotsTxt(), compress(), astroImageTools],
 	vite: {
 		css: {


### PR DESCRIPTION
This is to get pretty URLs without trailing slashes like `kainoa.us/posts` instead of `kainoa.us/posts/`